### PR TITLE
Set version in pjson

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jquery-idletimer",
   "main": "dist/idle-timer.js",
-  "version": "0.0.0-ignored",
+  "version": "1.1.0",
   "engines": {
     "node": ">= 0.6.0"
   },
@@ -17,7 +17,7 @@
     "grunt-contrib-concat": "0.3.0",
     "grunt-contrib-uglify": "0.4.0",
     "grunt-contrib-watch": "0.6.0",
-	"grunt-coveralls": "0.3.0",
+    "grunt-coveralls": "0.3.0",
     "grunt-qunit-istanbul": "^0.4.0",
     "grunt": "0.4.2"
   },


### PR DESCRIPTION
Sets the version in package.json.

Indents the line that was mis-indented previously.

I request to republish a tag 1.1.0 after merge so tools such as JSPM can use this without overriding the `main` property. Since last change to add that, a tag publish is pending.