### PR TITLE
Issue #47 fix

### DIFF
--- a/src/idle-timer.js
+++ b/src/idle-timer.js
@@ -299,9 +299,7 @@
          * @param {Event} event A DOM2-normalized event object.
          * @return {void}
          */
-        jqElem.on($.trim((opts.events + " ").split(" ").join("._idleTimer ")), function (e) {
-            handleEvent(e);
-        });
+        jqElem.on($.trim((opts.events + " ").split(" ").join("._idleTimer ")), handleEvent);
 
         if (opts.timerSyncId) {
             $(window).bind("storage", handleEvent);

--- a/src/idle-timer.js
+++ b/src/idle-timer.js
@@ -281,6 +281,7 @@
             return obj.idle;
         }
 
+	/*
 	// Test via a getter in the options object to see if the passive property is accessed
         var supportsPassive = false;
         try {
@@ -291,7 +292,8 @@
             });
             window.addEventListener("test", null, Popts);
         } catch (e) {}
-
+	*/
+	    
         /* (intentionally not documented)
          * Handles a user event indicating that the user isn't idle. namespaced with internal idleTimer
          * @param {Event} event A DOM2-normalized event object.
@@ -299,7 +301,7 @@
          */
         jqElem.on($.trim((opts.events + " ").split(" ").join("._idleTimer ")), function (e) {
             handleEvent(e);
-        }, supportsPassive ? { passive: true } : false);
+        });
 
         if (opts.timerSyncId) {
             $(window).bind("storage", handleEvent);

--- a/src/idle-timer.js
+++ b/src/idle-timer.js
@@ -293,7 +293,7 @@
             window.addEventListener("test", null, Popts);
         } catch (e) {}
 	*/
-	    
+
         /* (intentionally not documented)
          * Handles a user event indicating that the user isn't idle. namespaced with internal idleTimer
          * @param {Event} event A DOM2-normalized event object.


### PR DESCRIPTION
This fix will result in not using passive event handlers when available, and will need additional work to fix that. Since most browsers don't support passive event listeners yet, this is better then plugin constantly throwing js errors.